### PR TITLE
Execute the Case service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM openjdk:8-jre-slim
 
-ARG JAR_FILE=census-rm-casesvc*.jar
+VOLUME /tmp
+ARG JAR_FILE=casesvc*.jar
 RUN apt-get update
-RUN apt-get -yq install curl
 RUN apt-get -yq clean
-COPY target/$JAR_FILE /opt/census-rm-casesvc.jar
 
-ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/census-rm-casesvc.jar" ]
+RUN groupadd --gid 999 casesvc && \
+    useradd --create-home --system --uid 999 --gid casesvc casesvc
+USER casesvc
 
+COPY target/$JAR_FILE /opt/casesvc.jar
+
+ENTRYPOINT [ "java", "-jar", "/opt/casesvc.jar" ]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

**IMPORTANT: Note that this change must be merged at the same time as [the pull request to update the Kubernetes manifests for this change](https://github.com/ONSdigital/census-rm-kubernetes/pull/29).**

# What has changed
The Dockerfile has been changed:

* cURL should not be installed as it increases the attack surface of the container
* Create a dedicated non-root user account for executing the Java code
* The existing `ENTRYPOINT` command was poorly-formed:
  - The use of `sh -c` does not pass Unix signals to the Java process
  - When using the _exec_ form of `ENTRYPOINT` each argument should be its own array element
  - The `JAVA_OPTS` environment variable is Tomcat-specific and may be omitted. A separate PR linked below addresses passing options to the JVM via the standard `JAVA_TOOL_OPTIONS` environment variable

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Java process running as the expected non-root user account 

# Links
* https://docs.docker.com/engine/reference/builder/#entrypoint
* https://github.com/ONSdigital/census-rm-kubernetes/pull/14
https://github.com/ONSdigital/census-rm-kubernetes/pull/29